### PR TITLE
Update git-what to use env to find bash

### DIFF
--- a/git-what
+++ b/git-what
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # git what Copyright (C) 2017 Andy Balaam, released under GPLv2 or later.
 


### PR DESCRIPTION
Update the #! to a more friendly path so it can run on FreeBSD and  Linux distros that don't have bash at '/bin/bash'